### PR TITLE
added missing argument to fix deprecated warning

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/injector/IndevVanillaTweakInjector.java
+++ b/src/main/java/net/minecraft/launchwrapper/injector/IndevVanillaTweakInjector.java
@@ -69,7 +69,7 @@ public class IndevVanillaTweakInjector implements IClassTransformer {
                     }
 
                     instruction = iterator.next();
-                    runMethod.instructions.insertBefore(instruction, new MethodInsnNode(INVOKESTATIC, "net/minecraft/launchwrapper/injector/IndevVanillaTweakInjector", "inject", "()Ljava/io/File;"));
+                    runMethod.instructions.insertBefore(instruction, new MethodInsnNode(INVOKESTATIC, "net/minecraft/launchwrapper/injector/IndevVanillaTweakInjector", "inject", "()Ljava/io/File;", false));
                     runMethod.instructions.insertBefore(instruction, new VarInsnNode(ASTORE, 2));
                 }
             }


### PR DESCRIPTION
new parameter: boolean itf if the method's owner class is an interface.