### PR TITLE
added missing argument to fix deprecated warning

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/injector/VanillaTweakInjector.java
+++ b/src/main/java/net/minecraft/launchwrapper/injector/VanillaTweakInjector.java
@@ -64,7 +64,7 @@ public class VanillaTweakInjector implements IClassTransformer {
         injectedMethod.visitLabel(label);
         injectedMethod.visitLineNumber(9001, label); // Linenumber which shows up in the stacktrace
         // Call the method below
-        injectedMethod.visitMethodInsn(INVOKESTATIC, "net/minecraft/launchwrapper/injector/VanillaTweakInjector", "inject", "()Ljava/io/File;");
+        injectedMethod.visitMethodInsn(INVOKESTATIC, "net/minecraft/launchwrapper/injector/VanillaTweakInjector", "inject", "()Ljava/io/File;", false);
         // Store the result in the workDir variable.
         injectedMethod.visitFieldInsn(PUTSTATIC, "net/minecraft/client/Minecraft", workDirNode.name, "Ljava/io/File;");
 


### PR DESCRIPTION
new parameter: boolean itf if the method's owner class is an interface.